### PR TITLE
Fix bug with get_terms

### DIFF
--- a/extensions/population-method-categories/class-fw-extension-population-method-categories.php
+++ b/extensions/population-method-categories/class-fw-extension-population-method-categories.php
@@ -79,8 +79,10 @@ class FW_Extension_Population_Method_Categories extends FW_Extension implements 
 	private function get_terms($post_type)
 	{
 		$taxonomies = get_taxonomies(array('object_type' => array($post_type), 'hierarchical' => true));
-
-		return get_terms($taxonomies);
+		if (count($taxonomies)) {
+			return get_terms($taxonomies);
+		}
+		return $taxonomies;
 	}
 
 	private function get_post_categories_sets()


### PR DESCRIPTION
When `get_terms` get empty array he will return all categories.

**Example 1**
When we try to get categories for **Pages** (Pages don't have any categories)

```
get_taxonomies(array('object_type' => array('page'), 'hierarchical' => true))
```

will return empty array.

```
get_terms( array() )
```

So, our result is all categories.
![Image](https://i.gyazo.com/248489c03fc69c63479950dc31dc8bfc.png)

**Example 2**
Get blog posts categories.

```
get_terms( array('category') )
```

Good result.
![Image2](https://i.gyazo.com/0bd074a41a7903a9e06d3f7e8d1d013b.png)
